### PR TITLE
Fix a typo in UniqueMode constants

### DIFF
--- a/card.go
+++ b/card.go
@@ -498,10 +498,10 @@ const (
 	// results will be omitted.
 	UniqueModeArt UniqueMode = "art"
 
-	// UniqueModePrint returns all prints for all cards matched (disables
+	// UniqueModePrints returns all prints for all cards matched (disables
 	// rollup). For example, if your search matches more than one print of
 	// Pacifism, all matching prints will be returned.
-	UniqueModePrint UniqueMode = "prints"
+	UniqueModePrints UniqueMode = "prints"
 )
 
 // Order is a method used to sort cards.

--- a/card.go
+++ b/card.go
@@ -501,7 +501,7 @@ const (
 	// UniqueModePrint returns all prints for all cards matched (disables
 	// rollup). For example, if your search matches more than one print of
 	// Pacifism, all matching prints will be returned.
-	UniqueModePrint UniqueMode = "print"
+	UniqueModePrint UniqueMode = "prints"
 )
 
 // Order is a method used to sort cards.

--- a/examples_test.go
+++ b/examples_test.go
@@ -15,7 +15,7 @@ func ExampleClient_SearchCards() {
 	}
 
 	so := scryfall.SearchCardsOptions{
-		Unique:        scryfall.UniqueModePrint,
+		Unique:        scryfall.UniqueModePrints,
 		Order:         scryfall.OrderSet,
 		Dir:           scryfall.DirDesc,
 		IncludeExtras: true,


### PR DESCRIPTION
First off, this wrapper for the Scryfall API is really useful-you saved me from writing my own, so thank you!

The constant for configuring the `UniqueMode` to include all cards in the search (`UniqueModePrint`) is wrong (probably the result of an API change, or a typo.) It is "print", but it should be "prints", as per the [official API docs](https://scryfall.com/docs/api/cards/search).