### PR TITLE
Update the sets and set types

### DIFF
--- a/set.go
+++ b/set.go
@@ -78,12 +78,22 @@ const (
 // Set is an object which represents a group of related Magic cards. All Card
 // objects on Scryfall belong to exactly one set.
 type Set struct {
+	// ID is a unique ID for this set in Scryfall’s database.
+	ID string `json:"id"`
+
 	// Code is the unique three or four-letter code for this set.
 	Code string `json:"code"`
 
 	// MTGOCode is the unique code for this set on MTGO, which may differ
 	// from the regular code.
-	MTGOCode string `json:"mtgo_code"`
+	MTGOCode *string `json:"mtgo_code"`
+
+	// ArenaCode is the unique code for this set on Magic: The Gathering Arena,
+	// which may differ from the regular code.
+	ArenaCode *string `json:"arena_code"`
+
+	// TCGplayerID is the set ID on TCGplayer's API, also known as the groupId.
+	TCGplayerID *string `json:"tcgplayer_id"`
 
 	// Name is the English name of the set.
 	Name string `json:"name"`
@@ -117,8 +127,8 @@ type Set struct {
 	// Digital is true if this set was only released on Magic Online.
 	Digital bool `json:"digital"`
 
-	// Foil is true if this set contains only foil cards.
-	Foil bool `json:"foil"`
+	// FoilOnly is true if this set contains only foil cards.
+	FoilOnly bool `json:"foil_only"`
 
 	// IconSVGURI is a URI to an SVG file for this set’s icon on Scryfall’s
 	// CDN. Hotlinking this image isn’t recommended, because it may change

--- a/set.go
+++ b/set.go
@@ -27,20 +27,26 @@ const (
 	// SetTypeFromTheVault is a From the Vault gift set.
 	SetTypeFromTheVault SetType = "from_the_vault"
 
+	// SetTypeSpellbook is a Spellbook series gift set.
+	SetTypeSpellbook SetType = "spellbook"
+
 	// SetTypePremiumDeck is a premium Deck Series decks set.
 	SetTypePremiumDeck SetType = "premium_deck"
 
 	// SetTypeDuelDeck is a Duel Decks set.
 	SetTypeDuelDeck SetType = "duel_deck"
 
+	// SetTypeDraftInnovation is a special draft set, like Conspiracy and Battlebond
+	SetTypeDraftInnovation SetType = "draft_innovation"
+
+	// SetTypeTreasureChest is a Magic Online treasure chest prize set.
+	SetTypeTreasureChest SetType = "treasure_chest"
+
 	// SetTypeCommander is a commander preconstructed set.
 	SetTypeCommander SetType = "commander"
 
 	// SetTypePlanechase is a Planechase set.
 	SetTypePlanechase SetType = "planechase"
-
-	// SetTypeConspiracy is a Conspiracy set.
-	SetTypeConspiracy SetType = "conspiracy"
 
 	// SetTypeArchenemy is an Archenemy set.
 	SetTypeArchenemy SetType = "archenemy"

--- a/set_test.go
+++ b/set_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestListSets(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `{"object": "list", "has_more": false, "data": [{"object": "set", "code": "dom", "mtgo_code": "dom", "name": "Dominaria", "uri": "https://api.scryfall.com/sets/dom", "scryfall_uri": "https://scryfall.com/sets/dom", "search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Adom&unique=prints", "released_at": "2018-04-27", "set_type": "expansion", "card_count": 142, "digital": false, "foil": false, "icon_svg_uri": "https://assets.scryfall.com/assets/sets/dom.svg"}, {"object": "set", "code": "a25", "name": "Masters 25", "uri": "https://api.scryfall.com/sets/a25", "scryfall_uri": "https://scryfall.com/sets/a25", "search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aa25&unique=prints", "released_at": "2018-03-16", "set_type": "masters", "card_count": 249, "digital": false, "foil": false, "icon_svg_uri": "https://assets.scryfall.com/assets/sets/a25.svg"},{"object":"set","code":"rix","mtgo_code":"rix","name":"Rivals of Ixalan","uri":"https://api.scryfall.com/sets/rix","scryfall_uri":"https://scryfall.com/sets/rix","search_uri":"https://api.scryfall.com/cards/search?order=set\u0026q=e%3Arix\u0026unique=prints","released_at":"2018-01-19","set_type":"expansion","card_count":205,"digital":false,"foil":false,"block_code":"xln","block":"Ixalan","icon_svg_uri":"https://assets.scryfall.com/assets/sets/rix.svg"}]}`)
+		fmt.Fprintln(w, `{"object": "list", "has_more": false, "data": [{"object": "set", "code": "dom", "mtgo_code": "dar", "arena_code": "dar", "name": "Dominaria", "uri": "https://api.scryfall.com/sets/dom", "scryfall_uri": "https://scryfall.com/sets/dom", "search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Adom&unique=prints", "released_at": "2018-04-27", "set_type": "expansion", "card_count": 142, "digital": false, "foil": false, "icon_svg_uri": "https://assets.scryfall.com/assets/sets/dom.svg"}, {"object": "set", "code": "a25", "mtgo_code": "a25", "arena_code": "a25", "name": "Masters 25", "uri": "https://api.scryfall.com/sets/a25", "scryfall_uri": "https://scryfall.com/sets/a25", "search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aa25&unique=prints", "released_at": "2018-03-16", "set_type": "masters", "card_count": 249, "digital": false, "foil": false, "icon_svg_uri": "https://assets.scryfall.com/assets/sets/a25.svg"},{"object":"set","code":"rix","mtgo_code":"rix","arena_code":"rix","name":"Rivals of Ixalan","uri":"https://api.scryfall.com/sets/rix","scryfall_uri":"https://scryfall.com/sets/rix","search_uri":"https://api.scryfall.com/cards/search?order=set\u0026q=e%3Arix\u0026unique=prints","released_at":"2018-01-19","set_type":"expansion","card_count":205,"digital":false,"foil":false,"block_code":"xln","block":"Ixalan","icon_svg_uri":"https://assets.scryfall.com/assets/sets/rix.svg"}]}`)
 	})
 	client, ts, err := setupTestServer("/sets", handler)
 	if err != nil {
@@ -25,10 +25,21 @@ func TestListSets(t *testing.T) {
 		t.Fatalf("Error listing sets: %v", err)
 	}
 
+	mtgoCodes := []string{
+		"dar",
+		"a25",
+		"rix",
+	}
+	arenaCodes := []string{
+		"dar",
+		"a25",
+		"rix",
+	}
 	want := []Set{
 		{
 			Code:        "dom",
-			MTGOCode:    "dom",
+			MTGOCode:    &mtgoCodes[0],
+			ArenaCode:   &arenaCodes[0],
 			Name:        "Dominaria",
 			URI:         "https://api.scryfall.com/sets/dom",
 			ScryfallURI: "https://scryfall.com/sets/dom",
@@ -37,12 +48,13 @@ func TestListSets(t *testing.T) {
 			SetType:     "expansion",
 			CardCount:   142,
 			Digital:     false,
-			Foil:        false,
+			FoilOnly:    false,
 			IconSVGURI:  "https://assets.scryfall.com/assets/sets/dom.svg",
 		},
 		{
 			Code:        "a25",
-			MTGOCode:    "",
+			MTGOCode:    &mtgoCodes[1],
+			ArenaCode:   &arenaCodes[1],
 			Name:        "Masters 25",
 			URI:         "https://api.scryfall.com/sets/a25",
 			ScryfallURI: "https://scryfall.com/sets/a25",
@@ -51,12 +63,13 @@ func TestListSets(t *testing.T) {
 			SetType:     "masters",
 			CardCount:   249,
 			Digital:     false,
-			Foil:        false,
+			FoilOnly:    false,
 			IconSVGURI:  "https://assets.scryfall.com/assets/sets/a25.svg",
 		},
 		{
 			Code:        "rix",
-			MTGOCode:    "rix",
+			MTGOCode:    &mtgoCodes[2],
+			ArenaCode:   &arenaCodes[2],
 			Name:        "Rivals of Ixalan",
 			URI:         "https://api.scryfall.com/sets/rix",
 			ScryfallURI: "https://scryfall.com/sets/rix",
@@ -65,7 +78,7 @@ func TestListSets(t *testing.T) {
 			SetType:     "expansion",
 			CardCount:   205,
 			Digital:     false,
-			Foil:        false,
+			FoilOnly:    false,
 			BlockCode:   stringPointer("xln"),
 			Block:       stringPointer("Ixalan"),
 			IconSVGURI:  "https://assets.scryfall.com/assets/sets/rix.svg",
@@ -92,11 +105,13 @@ func TestGetSet(t *testing.T) {
 		t.Fatalf("Error getting set: %v", err)
 	}
 
+	aetherSetCode := "aer"
 	aetherRevoltBlockCode := "kld"
 	aetherRevoltBlock := "Kaladesh"
 	want := Set{
-		Code:        "aer",
-		MTGOCode:    "aer",
+		Code:        aetherSetCode,
+		MTGOCode:    &aetherSetCode,
+		ArenaCode:   nil,
 		Name:        "Aether Revolt",
 		URI:         "https://api.scryfall.com/sets/aer",
 		ScryfallURI: "https://scryfall.com/sets/aer",
@@ -105,7 +120,7 @@ func TestGetSet(t *testing.T) {
 		SetType:     "expansion",
 		CardCount:   194,
 		Digital:     false,
-		Foil:        false,
+		FoilOnly:    false,
 		BlockCode:   &aetherRevoltBlockCode,
 		Block:       &aetherRevoltBlock,
 		IconSVGURI:  "https://assets.scryfall.com/assets/sets/aer.svg",


### PR DESCRIPTION
I added several missing set fields and set types according to https://scryfall.com/docs/api/sets.

Note: `arena_code` is not specified in the documentation, but it is returned by https://api.scryfall.com/sets.