### PR TITLE
Bulk struct fixes

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -16,6 +16,9 @@ type BulkData struct {
 	// Name is a human-readable name for this file.
 	Name string `json:"name"`
 
+	// URI is a link to this bulk object on Scryfall’s API.
+	URI string `json:"uri"`
+
 	// Description is a human-readable name for this file.
 	Description string `json:"description"`
 

--- a/bulk.go
+++ b/bulk.go
@@ -22,8 +22,8 @@ type BulkData struct {
 	// CompressedSize is the compressed size of this file in integer bytes.
 	CompressedSize int `json:"compressed_size"`
 
-	// PermalinkURI is the URL that hosts this bulk file.
-	PermalinkURI string `json:"permalink_uri"`
+	// DownloadURI is the URL that hosts this bulk file.
+	DownloadURI string `json:"download_uri"`
 
 	// ContentType is the MIME type of this file.
 	ContentType string `json:"content_type"`


### PR DESCRIPTION
Scryfall updated their [API](https://scryfall.com/docs/api/bulk-data) to no longer have a `permalink_uri`
* Add missing `uri` property
* Update `permalink_uri` to the new `download_uri`
