### PR TITLE
Add missing layout and frame effect

### DIFF
--- a/card.go
+++ b/card.go
@@ -83,6 +83,9 @@ const (
 	// LayoutTransform is a double-sided card layout that transforms.
 	LayoutTransform Layout = "transform"
 
+	// LayoutModalDFC is a double-sided card layout that can be played either-side
+	LayoutModalDFC Layout = "modal_dfc"
+
 	// LayoutMeld is a card layout with meld parts printed on the back.
 	LayoutMeld Layout = "meld"
 

--- a/card.go
+++ b/card.go
@@ -228,6 +228,9 @@ const (
 
 	// FrameEffectExtendedArt is an extended art frame effect.
 	FrameEffectExtendedArt FrameEffect = "extendedart"
+
+	// FrameEffectCompanion is a companion frame effect.
+	FrameEffectCompanion FrameEffect = "companion"
 )
 
 type Preview struct {


### PR DESCRIPTION
This PR adds the `modal_dfc` layout (according to <https://scryfall.com/docs/api/layouts#layout>) and the `companion` following frame effect (according to <https://scryfall.com/docs/api/layouts#frame-effects>).