### PR TITLE
Marshal Date using the same format UnmarshalJSON expects.

### DIFF
--- a/scryfall.go
+++ b/scryfall.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	defaultBaseURL = "https://api.scryfall.com"
-	defaultTimeout = 30 * time.Second
+	defaultBaseURL      = "https://api.scryfall.com"
+	defaultTimeout      = 30 * time.Second
 	defaultReqPerSecond = 10
-	userAgent      = "go-scryfall"
+	userAgent           = "go-scryfall"
 
 	dateFormat      = "2006-01-02"
 	timestampFormat = "2006-01-02T15:04:05.999Z07:00"
@@ -72,6 +72,10 @@ func (d *Date) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+func (d *Date) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%s\"", d.Format(dateFormat))), nil
+}
+
 // Timestamp is a timestamp returned by the Scryfall API.
 type Timestamp struct {
 	time.Time
@@ -110,7 +114,7 @@ type clientOptions struct {
 	clientSecret string
 	grantSecret  string
 	client       *http.Client
-	limiter ratelimit.Limiter
+	limiter      ratelimit.Limiter
 }
 
 // ClientOption configures the Scryfall API client.
@@ -161,7 +165,7 @@ type Client struct {
 	baseURL       *url.URL
 	authorization string
 
-	client *http.Client
+	client  *http.Client
 	limiter ratelimit.Limiter
 }
 
@@ -199,7 +203,7 @@ func NewClient(options ...ClientOption) (*Client, error) {
 		baseURL:       baseURL,
 		authorization: authorization,
 		client:        co.client,
-		limiter: co.limiter,
+		limiter:       co.limiter,
 	}
 	return c, nil
 }
@@ -214,7 +218,7 @@ func (c *Client) doReq(ctx context.Context, req *http.Request, respBody interfac
 	if c.limiter != nil {
 		c.limiter.Take()
 	}
-	
+
 	resp, err := c.client.Do(reqWithContext)
 	if err != nil {
 		return err

--- a/scryfall_test.go
+++ b/scryfall_test.go
@@ -65,6 +65,55 @@ func TestDateUnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestDateMarshalJSON(t *testing.T) {
+	tests := []struct {
+		in  Date
+		out []byte
+	}{
+		{
+			Date{Time: time.Date(2018, 4, 27, 0, 0, 0, 0, time.FixedZone("UTC-8", -8*60*60))},
+			[]byte("\"2018-04-27\""),
+		},
+	}
+	for _, test := range tests {
+		t.Run(string(test.out), func(t *testing.T) {
+			got, err := test.in.MarshalJSON()
+			if err != nil {
+				t.Fatalf("Unexpected error while marshaling date: %v", err)
+			}
+			if string(got) != string(test.out) {
+				t.Errorf("got: %s want: %s", got, test.out)
+			}
+		})
+	}
+}
+
+func TestDateUnmashalMarshaledJSON(t *testing.T) {
+	tests := []struct {
+		in Date
+	}{
+		{
+			Date{Time: time.Date(2018, 4, 27, 0, 0, 0, 0, time.FixedZone("UTC-8", -8*60*60))},
+		},
+	}
+	for _, test := range tests {
+		t.Run(string(test.in.Time.Format(dateFormat)), func(t *testing.T) {
+			marshaled, err := test.in.MarshalJSON()
+			if err != nil {
+				t.Fatalf("Unexpected error while marshaling date: %v", err)
+			}
+			var out Date
+			err = out.UnmarshalJSON(marshaled)
+			if err != nil {
+				t.Fatalf("Unexpected error while unmarshaling JSON date: %v", err)
+			}
+			if !out.Time.Equal(test.in.Time) {
+				t.Errorf("got: %s want: %s", out, test.in)
+			}
+		})
+	}
+}
+
 func TestTimestampUnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		in  []byte


### PR DESCRIPTION
`scryfall.Date` is marshaled as a timestamp, which makes unmarshaling `scryfall.Set`s fail unless either marshaling or unmarshaling is customized. 