### PR TITLE
Add version to User-Agent header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.6.0
+
+* Add version to User-Agent header
+* Add WithUserAgent option to enable customization of the User-Agent header


### PR DESCRIPTION
Scryfall has requested that the version is included in the User-Agent header. Lets do that to avoid future trouble. Also add the ability to customize the User-Agent header.

Fixes #31